### PR TITLE
[YOSEGI-8] Hive's parser uses Text's byte array.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveStringPrimitiveConverter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveStringPrimitiveConverter.java
@@ -42,11 +42,9 @@ public class HiveStringPrimitiveConverter implements IHivePrimitiveConverter {
       return NullObj.getInstance();
     }
     Text text = inspector.getPrimitiveWritableObject( target );
-    if ( text.getLength() == text.getBytes().length ) {
-      return new BytesStringObj( text.getBytes() );
-    } else {
-      return new BytesStringObj( text.getBytes() , 0 , text.getLength() );
-    }
+    byte[] data = new byte[text.getLength() ];
+    System.arraycopy( text.getBytes() , 0 , data , 0 , data.length );
+    return new BytesStringObj( data );
   }
 
 }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
By referring to the byte array, it becomes an invalid value in the case of text data.
Changed to copy values to byte array at instance creation instead of byte array reference.

### How did you do the test? (Not required for updating documents)
