### PR TITLE
[Yosegi-3] Security alert org.apache.hive:hive-exec

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,16 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
 # Hive's quick start with Yosegi
 
 ## Preparation

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,6 @@
   </developers>
 
   <properties>
-    <configlibVersion>1.2.1.1</configlibVersion>
-    <schemalibVersion>1.2.4_hive-1.2.1000.2.6.4.0-91</schemalibVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <target_jdk_version>1.8</target_jdk_version>
     <maven-surefire-plugin.version>3.0.0-M2</maven-surefire-plugin.version>
@@ -77,7 +75,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <version>1.2.1000.2.6.4.0-91</version>
+      <version>2.3.4</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -195,6 +193,7 @@
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
+            <exclude>jars/**/*</exclude>
             <exclude>**/*.json</exclude>
             <exclude>**/*.txt</exclude>
             <exclude>**/*.template</exclude>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
To accommodate security alerts.
Changed support version of Hive to 2.3.4.

### How did you do the test? (Not required for updating documents)
