### PR TITLE
[Yosegi-36]The Timestamp interface is different in Hive 3.X.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveDatePrimitiveConverter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveDatePrimitiveConverter.java
@@ -39,7 +39,7 @@ public class HiveDatePrimitiveConverter implements IHivePrimitiveConverter {
     if ( target == null ) {
       return NullObj.getInstance();
     }
-    return new LongObj( inspector.getPrimitiveJavaObject( target ).getTime() );
+    return new LongObj( inspector.getPrimitiveJavaObject( target ).toEpochMilli() );
   }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveTimestampPrimitiveConverter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveTimestampPrimitiveConverter.java
@@ -39,7 +39,7 @@ public class HiveTimestampPrimitiveConverter implements IHivePrimitiveConverter 
     if ( target == null ) {
       return NullObj.getInstance();
     }
-    return new LongObj( inspector.getPrimitiveJavaObject( target ).getTime() );
+    return new LongObj( inspector.getPrimitiveJavaObject( target ).toEpochMilli() );
   }
 
 }

--- a/src/test/java/jp/co/yahoo/yosegi/message/parser/hive/TestHiveTimestampPrimitiveConverter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/message/parser/hive/TestHiveTimestampPrimitiveConverter.java
@@ -25,14 +25,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
 
-import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 
 import jp.co.yahoo.yosegi.message.objects.NullObj;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 
 import java.io.IOException;
-import java.sql.Timestamp;
 
 public class TestHiveTimestampPrimitiveConverter {
 
@@ -42,7 +42,7 @@ public class TestHiveTimestampPrimitiveConverter {
         PrimitiveObjectInspectorFactory.writableTimestampObjectInspector );
 
     long t = 1551756114L;
-    TimestampWritable timestamp = new TimestampWritable( new Timestamp( t ) );
+    TimestampWritableV2 timestamp = new TimestampWritableV2( Timestamp.ofEpochMilli( t ) );
     PrimitiveObject tObj = converter.get( timestamp );
     assertEquals( t , tObj.getLong() );
   }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Fixed the code because Date interface is different in 3.X.

### How did you do the test? (Not required for updating documents)
