### PR TITLE
add license for hive-1.2.1000.2.6.4.0-91 only

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,16 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
 # Hive's quick start with Yosegi
 
 ## Preparation


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
License description is missing in the document at hive-1.2.1000.2.6.4.0-91 only.
Then, I add the license to the document.

### How did you do the test? (Not required for updating documents)
