### PR TITLE
Yosegi-82 Writing to Map type with Spark sql will be empty.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveMapParser.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveMapParser.java
@@ -35,12 +35,20 @@ public class HiveMapParser implements IHiveParser {
   private final ObjectInspector childObjectInspector;
   private final IHivePrimitiveConverter childConverter;
   private final boolean childHasParser;
+  private Map<String,Object> keyMapping = new HashMap<String,Object>();
   private Object row;
 
   /**
    * Initialize map information set.
    */
   public HiveMapParser( final MapObjectInspector mapObjectInspector ) {
+    IHivePrimitiveConverter keyConverter = HivePrimitiveConverterFactory.get(
+        mapObjectInspector.getMapKeyObjectInspector() );
+    if ( keyConverter instanceof HiveStringPrimitiveConverter ) {
+      throw new UnsupportedOperationException(
+          "Map type key only supports String type." );
+    }
+
     this.mapObjectInspector = mapObjectInspector;
     childObjectInspector = mapObjectInspector.getMapValueObjectInspector();
     childConverter = HivePrimitiveConverterFactory.get( childObjectInspector );
@@ -51,11 +59,19 @@ public class HiveMapParser implements IHiveParser {
   @Override
   public void setObject( final Object row ) throws IOException {
     this.row = row;
+    keyMapping.clear();
+    Map<?,?> map = mapObjectInspector.getMap( row );
+    Iterator<?> keyIterator = map.keySet().iterator();
+    while ( keyIterator.hasNext() ) {
+      Object keyObj = keyIterator.next();
+      keyMapping.put( keyObj.toString() , keyObj );
+    }
   }
 
   @Override
   public PrimitiveObject get(final String key ) throws IOException {
-    return childConverter.get( mapObjectInspector.getMapValueElement( row , new Text( key ) ) );
+    return childConverter.get(
+        mapObjectInspector.getMapValueElement( row , keyMapping.get( key ) ) );
   }
 
   @Override
@@ -66,7 +82,7 @@ public class HiveMapParser implements IHiveParser {
   @Override
   public IParser getParser( final String key ) throws IOException {
     IHiveParser childParser =  HiveParserFactory.get( childObjectInspector );
-    childParser.setObject( mapObjectInspector.getMapValueElement( row , new Text( key ) ) );
+    childParser.setObject( mapObjectInspector.getMapValueElement( row , keyMapping.get( key ) ) );
     return childParser;
   }
 
@@ -77,14 +93,12 @@ public class HiveMapParser implements IHiveParser {
 
   @Override
   public String[] getAllKey() throws IOException {
-    Map<?,?> map = mapObjectInspector.getMap( row );
+    String[] keys = new String[keyMapping.size()];
 
-    String[] keys = new String[map.size()];
-
-    Iterator<?> keyIterator = map.keySet().iterator();
+    Iterator<String> keyIterator = keyMapping.keySet().iterator();
     int index = 0;
     while ( keyIterator.hasNext() ) {
-      keys[index] = keyIterator.next().toString();
+      keys[index] = keyIterator.next();
       index++;
     }
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

The key when referencing a Map type value is not necessarily Text.
In the current code, when creating a table from Spark, the contents of the map will be empty.
Has a mapping between key and Object internally.

### How did you do the test? (Not required for updating documents)
