### PR TITLE
Yosegi-83 In the Hive Parser nested type, the child object is not NullParser even though it is NULL.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveListParser.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveListParser.java
@@ -74,8 +74,12 @@ public class HiveListParser implements IHiveParser {
   @Override
   public IParser getParser( final int index ) throws IOException {
     if ( index < size() ) {
+      Object childRow = listObjectInspector.getListElement( row , index );
+      if ( childRow == null ) {
+        return new HiveNullParser();
+      }
       IHiveParser childParser = HiveParserFactory.get( childObjectInspector );
-      childParser.setObject( listObjectInspector.getListElement( row , index ) );
+      childParser.setObject( childRow );
       return childParser;
     } else {
       return new HiveNullParser();

--- a/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveStructParser.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/parser/hive/HiveStructParser.java
@@ -90,9 +90,13 @@ public class HiveStructParser implements IHiveParser {
 
   @Override
   public IParser getParser( final int index ) throws IOException {
+    Object childRow = inspector.getStructFieldData( row, fieldList.get( index ) );
+    if ( childRow == null ) {
+      return new HiveNullParser();
+    }
     IHiveParser childParser =
         HiveParserFactory.get( fieldList.get( index ).getFieldObjectInspector() );
-    childParser.setObject( inspector.getStructFieldData( row, fieldList.get( index ) ) );
+    childParser.setObject( childRow );
     return childParser;
   }
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

Added processing assuming Null.
It was confirmed that even if the Map type is NULL in Hive, it can be referenced normally.

### How did you do the test? (Not required for updating documents)
