### PR TITLE
[hive-3.1.1]Rollback to 0.10.4_hive-3.1.1

### DIFF
--- a/.circleci/.maven.xml
+++ b/.circleci/.maven.xml
@@ -3,7 +3,7 @@
     <servers>
         <server>
             <!-- Maven Central Deployment -->
-            <id>rso</id>
+            <id>ossrh</id>
             <username>${env.SONATYPE_USERNAME}</username>
             <password>${env.SONATYPE_PASSWORD}</password>
         </server>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi-hive</artifactId>
-  <version>0.10.5_hive-3.1.1-SNAPSHOT</version>
+  <version>0.10.4_hive-3.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Yosegi Hive</name>
   <description>Yosegi Hive library.</description>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
rollback to 0.10.4_hive-3.1.1

### How did you do the test? (Not required for updating documents)
I have to check it on the circleci by this pullrequest.
