### PR TITLE
Fixed a bug where Hive couldn't get Expand / Flatten settings properly.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/hive/YosegiSerde.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/YosegiSerde.java
@@ -120,23 +120,25 @@ public class YosegiSerde extends AbstractSerDe {
     String columnNameProperty = table.getProperty(serdeConstants.LIST_COLUMNS);
     String columnTypeProperty = table.getProperty(serdeConstants.LIST_COLUMN_TYPES);
 
-    conf.unset( "yosegi.expand" );
+    conf.unset( "spread.reader.expand.column" );
     Iterator<Map.Entry<String,String>> jobConfIterator = conf.iterator();
     while ( jobConfIterator.hasNext() ) {
       Map.Entry<String,String> keyValue = jobConfIterator.next();
-      if ( keyValue.getKey().startsWith( "yosegi.flatten" ) ) {
+      if ( keyValue.getKey().startsWith( "spread.reader.flatten.column" ) ) {
         conf.unset( keyValue.getKey() );
       }
     }
 
     if ( table.containsKey( "yosegi.expand" ) ) {
-      conf.set("yosegi.expand", table.getProperty( "yosegi.expand" ));
+      conf.set("spread.reader.expand.column", table.getProperty( "yosegi.expand" ));
     }
     Iterator<String> iterator = table.stringPropertyNames().iterator();
     while ( iterator.hasNext() ) {
       String keyName = iterator.next();
       if ( keyName.startsWith( "yosegi.flatten" ) ) {
-        conf.set( keyName , table.getProperty( keyName ) );
+        String yosegiKeyName = keyName.replace(
+            "yosegi.flatten" , "spread.reader.flatten.column" );
+        conf.set( yosegiKeyName , table.getProperty( keyName ) );
       }
     }
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

1. Renamed to a different name as it will be overwritten with the same name as the table property when passing values in Hadoop Configuration
2. Changed to get Expand / Flatten settings from mapWork if mapWork is not NULL


### How did you do the test? (Not required for updating documents)

I confirmed that it was improved in the query that can not be obtained by Hive.
