### PR TITLE
Support yosegi 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi-hive</artifactId>
-  <version>0.10.6_hive-1.2.1000.2.6.4.0-91-SNAPSHOT</version>
+  <version>2.0.0_hive-1.2.1000.2.6.4.0-91-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Yosegi Hive</name>
   <description>Yosegi Hive library.</description>
@@ -99,14 +99,19 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.10.8</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jp.co.yahoo.yosegi</groupId>
       <artifactId>yosegi</artifactId>
-      <version>0.10.6</version>
+      <version>2.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>jp.co.yahoo.yosegi</groupId>
+      <artifactId>yosegi-legacy</artifactId>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/YosegiHiveDirectVectorizedReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/YosegiHiveDirectVectorizedReader.java
@@ -21,9 +21,7 @@ package jp.co.yahoo.yosegi.hive.io;
 import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
 import jp.co.yahoo.yosegi.reader.YosegiReader;
 import jp.co.yahoo.yosegi.spread.Spread;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 import jp.co.yahoo.yosegi.spread.expression.IExpressionNode;
-import jp.co.yahoo.yosegi.spread.expression.IndexFactory;
 import jp.co.yahoo.yosegi.stats.SummaryStats;
 
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
@@ -51,7 +49,6 @@ public class YosegiHiveDirectVectorizedReader
   private final String[] columnNames;
 
   private boolean isEnd;
-  private IExpressionIndex currentIndexList;
   private int currentIndex;
   private int indexSize;
   private int readSpreadCount;
@@ -109,13 +106,8 @@ public class YosegiHiveDirectVectorizedReader
     }
     Spread spread = currentReader.next();
     readSpreadCount++;
-    if ( setting.isDisableFilterPushdown() ) {
-      currentIndexList = IndexFactory.toExpressionIndex( spread , null );
-    } else {
-      currentIndexList = IndexFactory.toExpressionIndex( spread , node.exec( spread ) );
-    }
   
-    indexSize = currentIndexList.size();
+    indexSize = spread.size();
     currentIndex = 0;
     if ( indexSize == 0 ) {
       return false;
@@ -167,7 +159,7 @@ public class YosegiHiveDirectVectorizedReader
 
     for ( int colIndex : needColumnIds ) {
       assignors[colIndex].setColumnVector(
-          outputBatch.cols[colIndex] , currentIndexList , currentIndex , maxSize );
+          outputBatch.cols[colIndex] , currentIndex , maxSize );
     }
     outputBatch.size = maxSize;
 

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/YosegiHiveLineReader.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/YosegiHiveLineReader.java
@@ -21,9 +21,7 @@ package jp.co.yahoo.yosegi.hive.io;
 import jp.co.yahoo.yosegi.reader.YosegiReader;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.spread.column.SpreadColumn;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 import jp.co.yahoo.yosegi.spread.expression.IExpressionNode;
-import jp.co.yahoo.yosegi.spread.expression.IndexFactory;
 import jp.co.yahoo.yosegi.stats.SummaryStats;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.RecordReader;
@@ -47,7 +45,6 @@ public class YosegiHiveLineReader implements RecordReader<NullWritable, ColumnAn
 
   private Spread currentSpread;
   private int currentIndex;
-  private IExpressionIndex currentIndexList;
   private boolean isEnd;
   private int readSpreadCount;
 
@@ -123,14 +120,8 @@ public class YosegiHiveLineReader implements RecordReader<NullWritable, ColumnAn
       return nextReader();
     }
     spreadCounter.increment();
-    if ( setting.isDisableFilterPushdown() ) {
-      currentIndexList = IndexFactory.toExpressionIndex( currentSpread , null );
-    } else {
-      currentIndexList =
-          IndexFactory.toExpressionIndex( currentSpread , node.exec( currentSpread ) );
-    }
     currentIndex = 0;
-    if ( currentIndexList.size() == 0 ) {
+    if ( currentSpread.size() == 0 ) {
       return nextReader();
     }
     return true;
@@ -138,7 +129,7 @@ public class YosegiHiveLineReader implements RecordReader<NullWritable, ColumnAn
 
   @Override
   public boolean next( final NullWritable key, final ColumnAndIndex value ) throws IOException {
-    if ( currentSpread == null || currentIndex == currentIndexList.size() ) {
+    if ( currentSpread == null || currentIndex == currentSpread.size() ) {
       if ( ! nextReader() ) {
         updateCounter( reader.getReadStats() );
         isEnd = true;
@@ -148,7 +139,7 @@ public class YosegiHiveLineReader implements RecordReader<NullWritable, ColumnAn
 
     spreadColumn.setSpread( currentSpread );
     value.column = spreadColumn;
-    value.index =  currentIndexList.get( currentIndex );
+    value.index =  currentIndex;
     value.columnIndex = spreadCounter.get();
     currentIndex++;
     return true;

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/BytePrimitiveSetter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/BytePrimitiveSetter.java
@@ -31,11 +31,11 @@ public class BytePrimitiveSetter implements INumberPrimitiveSetter {
 
   @Override
   public void set(
-      final PrimitiveObject[] primitiveObjectArray ,
+      final PrimitiveObject primitiveObject ,
       final LongColumnVector columnVector ,
       final int index ) throws IOException {
     try {
-      long longNumber = (long)( primitiveObjectArray[index].getByte() );
+      long longNumber = (long)( primitiveObject.getByte() );
       columnVector.vector[index] = longNumber;
     } catch ( NumberFormatException | NullPointerException ex ) {
       VectorizedBatchUtil.setNullColIsNullValue( columnVector , index );

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/BytesColumnVectorAssignor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/BytesColumnVectorAssignor.java
@@ -21,7 +21,6 @@ package jp.co.yahoo.yosegi.hive.io.vector;
 import jp.co.yahoo.yosegi.message.objects.IBytesLink;
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
@@ -41,24 +40,22 @@ public class BytesColumnVectorAssignor implements IColumnVectorAssignor {
   @Override
   public void setColumnVector(
       final ColumnVector vector ,
-      final IExpressionIndex indexList ,
       final int start ,
       final int length ) throws IOException {
     BytesColumnVector columnVector = (BytesColumnVector)vector;
 
-    PrimitiveObject[] primitiveObjectArray =
-        column.getPrimitiveObjectArray( indexList , start , length );
     for ( int i = 0 ; i < length ; i++ ) {
-      if ( primitiveObjectArray[i] == null ) {
+      PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , i + start );
+      if ( primitiveObject == null ) {
         VectorizedBatchUtil.setNullColIsNullValue( columnVector , i );
       } else {
-        if ( primitiveObjectArray[i] instanceof IBytesLink ) {
-          IBytesLink linkObj = (IBytesLink)primitiveObjectArray[i];
+        if ( primitiveObject instanceof IBytesLink ) {
+          IBytesLink linkObj = (IBytesLink)primitiveObject;
           columnVector.vector[i] = linkObj.getLinkBytes();
           columnVector.start[i] = linkObj.getStart();
           columnVector.length[i] = linkObj.getLength();
         } else {
-          byte[] strBytes = primitiveObjectArray[i].getBytes();
+          byte[] strBytes = primitiveObject.getBytes();
           if ( strBytes == null ) {
             VectorizedBatchUtil.setNullColIsNullValue( columnVector , i );
           } else {

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/ColumnUtil.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/ColumnUtil.java
@@ -19,32 +19,25 @@
 package jp.co.yahoo.yosegi.hive.io.vector;
 
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
-
-import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedBatchUtil;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
 
 import java.io.IOException;
 
-public final class LongPrimitiveSetter implements INumberPrimitiveSetter {
+public final class ColumnUtil {
 
-  private static final LongPrimitiveSetter SETTER = new LongPrimitiveSetter();
 
-  private LongPrimitiveSetter() {}
+  private ColumnUtil() {}
 
-  @Override
-  public void set(
-      final PrimitiveObject primitiveObject ,
-      final LongColumnVector columnVector ,
-      final int index ) throws IOException {
-    try {
-      columnVector.vector[index] = primitiveObject.getLong();
-    } catch ( NumberFormatException | NullPointerException ex ) {
-      VectorizedBatchUtil.setNullColIsNullValue( columnVector , index );
+  /**
+   * Extracts the element of the specified index from the column as PrimitiveObject.
+   */
+  public static PrimitiveObject getPrimitiveObject(
+      final IColumn column , final int columnIndex ) throws IOException {
+    Object obj = column.get( columnIndex ).getRow();
+    if ( ! ( obj instanceof PrimitiveObject ) ) {
+      return null;
     }
-  }
-
-  public static LongPrimitiveSetter getInstance() {
-    return SETTER;
+    return (PrimitiveObject) obj;
   }
 
 }

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/DoubleColumnVectorAssignor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/DoubleColumnVectorAssignor.java
@@ -20,7 +20,6 @@ package jp.co.yahoo.yosegi.hive.io.vector;
 
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
@@ -45,17 +44,15 @@ public class DoubleColumnVectorAssignor implements IColumnVectorAssignor {
   @Override
   public void setColumnVector(
       final ColumnVector vector ,
-      final IExpressionIndex indexList ,
       final int start ,
       final int length ) throws IOException {
     DoubleColumnVector columnVector = (DoubleColumnVector)vector;
-    PrimitiveObject[] primitiveObjectArray =
-        column.getPrimitiveObjectArray( indexList , start , length );
     for ( int i = 0 ; i < length ; i++ ) {
-      if ( primitiveObjectArray[i] == null ) {
+      PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , i + start );
+      if ( primitiveObject == null ) {
         VectorizedBatchUtil.setNullColIsNullValue( columnVector , i );
       } else {
-        setter.set( primitiveObjectArray , columnVector , i );
+        setter.set( primitiveObject , columnVector , i );
       }
     }
   }

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/DoublePrimitiveSetter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/DoublePrimitiveSetter.java
@@ -31,11 +31,11 @@ public class DoublePrimitiveSetter implements IDecimalPrimitiveSetter {
 
   @Override
   public void set(
-      final PrimitiveObject[] primitiveObjectArray ,
+      final PrimitiveObject primitiveObject ,
       final DoubleColumnVector columnVector ,
       final int index ) throws IOException {
     try {
-      double doubleNumber = primitiveObjectArray[index].getDouble();
+      double doubleNumber = primitiveObject.getDouble();
       columnVector.vector[index] = doubleNumber;
     } catch ( NumberFormatException | NullPointerException ex ) {
       VectorizedBatchUtil.setNullColIsNullValue( columnVector , index );

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/FloatPrimitiveSetter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/FloatPrimitiveSetter.java
@@ -31,11 +31,11 @@ public class FloatPrimitiveSetter implements IDecimalPrimitiveSetter {
 
   @Override
   public void set(
-      final PrimitiveObject[] primitiveObjectArray ,
+      final PrimitiveObject primitiveObject ,
       final DoubleColumnVector columnVector ,
       final int index ) throws IOException {
     try {
-      double doubleNumber = (double)( primitiveObjectArray[index].getFloat() );
+      double doubleNumber = (double)( primitiveObject.getFloat() );
       columnVector.vector[index] = doubleNumber;
     } catch ( NumberFormatException | NullPointerException ex ) {
       VectorizedBatchUtil.setNullColIsNullValue( columnVector , index );

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/IColumnVectorAssignor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/IColumnVectorAssignor.java
@@ -19,7 +19,6 @@
 package jp.co.yahoo.yosegi.hive.io.vector;
 
 import jp.co.yahoo.yosegi.spread.column.IColumn;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 
@@ -31,7 +30,6 @@ public interface IColumnVectorAssignor {
 
   void setColumnVector(
       final ColumnVector vector ,
-      final IExpressionIndex indexList ,
       final int start ,
       final int length ) throws IOException;
 

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/IDecimalPrimitiveSetter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/IDecimalPrimitiveSetter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public interface IDecimalPrimitiveSetter {
 
   void set(
-      final PrimitiveObject[] primitiveObjectArray ,
+      final PrimitiveObject primitiveObject ,
       final DoubleColumnVector columnVector ,
       final int index ) throws IOException;
 

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/INumberPrimitiveSetter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/INumberPrimitiveSetter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public interface INumberPrimitiveSetter {
 
   void set(
-      final PrimitiveObject[] primitiveObjectArray ,
+      final PrimitiveObject primitiveObject ,
       final LongColumnVector columnVector ,
       final int index ) throws IOException;
 

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/IntegerPrimitiveSetter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/IntegerPrimitiveSetter.java
@@ -31,11 +31,11 @@ public class IntegerPrimitiveSetter implements INumberPrimitiveSetter {
 
   @Override
   public void set(
-      final PrimitiveObject[] primitiveObjectArray ,
+      final PrimitiveObject primitiveObject ,
       final LongColumnVector columnVector ,
       final int index ) throws IOException {
     try {
-      long longNumber = (long)( primitiveObjectArray[index].getInt() );
+      long longNumber = (long)( primitiveObject.getInt() );
       columnVector.vector[index] = longNumber;
     } catch ( NumberFormatException | NullPointerException ex ) {
       VectorizedBatchUtil.setNullColIsNullValue( columnVector , index );

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/LongColumnVectorAssignor.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/LongColumnVectorAssignor.java
@@ -20,7 +20,6 @@ package jp.co.yahoo.yosegi.hive.io.vector;
 
 import jp.co.yahoo.yosegi.message.objects.PrimitiveObject;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
@@ -45,17 +44,15 @@ public class LongColumnVectorAssignor implements IColumnVectorAssignor {
   @Override
   public void setColumnVector(
       final ColumnVector vector ,
-      final IExpressionIndex indexList ,
       final int start ,
       final int length ) throws IOException {
     LongColumnVector columnVector = (LongColumnVector)vector;
-    PrimitiveObject[] primitiveObjectArray =
-        column.getPrimitiveObjectArray( indexList , start , length );
     for ( int i = 0 ; i < length ; i++ ) {
-      if ( primitiveObjectArray[i] == null ) {
+      PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , i + start );
+      if ( primitiveObject == null ) {
         VectorizedBatchUtil.setNullColIsNullValue( columnVector , i );
       } else {
-        setter.set( primitiveObjectArray , columnVector , i );
+        setter.set( primitiveObject , columnVector , i );
       }
     }
   }

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/ShortPrimitiveSetter.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/vector/ShortPrimitiveSetter.java
@@ -31,11 +31,11 @@ public class ShortPrimitiveSetter implements INumberPrimitiveSetter {
 
   @Override
   public void set(
-      final PrimitiveObject[] primitiveObjectArray ,
+      final PrimitiveObject primitiveObject ,
       final LongColumnVector columnVector ,
       final int index ) throws IOException {
     try {
-      long longNumber = (long)( primitiveObjectArray[index].getShort() );
+      long longNumber = (long)( primitiveObject.getShort() );
       columnVector.vector[index] = longNumber;
     } catch ( NumberFormatException | NullPointerException ex ) {
       VectorizedBatchUtil.setNullColIsNullValue( columnVector , index );

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/ColumnBinaryTestCase.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/ColumnBinaryTestCase.java
@@ -1,0 +1,275 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox;
+
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerConfig;
+import jp.co.yahoo.yosegi.binary.ColumnBinaryMakerCustomConfigNode;
+import jp.co.yahoo.yosegi.binary.CompressResultNode;
+import jp.co.yahoo.yosegi.binary.FindColumnBinaryMaker;
+import jp.co.yahoo.yosegi.binary.maker.IColumnBinaryMaker;
+import jp.co.yahoo.yosegi.inmemory.YosegiLoaderFactory;
+import jp.co.yahoo.yosegi.message.objects.BooleanObj;
+import jp.co.yahoo.yosegi.message.objects.ByteObj;
+import jp.co.yahoo.yosegi.message.objects.BytesObj;
+import jp.co.yahoo.yosegi.message.objects.DoubleObj;
+import jp.co.yahoo.yosegi.message.objects.FloatObj;
+import jp.co.yahoo.yosegi.message.objects.IntegerObj;
+import jp.co.yahoo.yosegi.message.objects.LongObj;
+import jp.co.yahoo.yosegi.message.objects.ShortObj;
+import jp.co.yahoo.yosegi.message.objects.StringObj;
+import jp.co.yahoo.yosegi.spread.column.ColumnType;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
+
+import java.io.IOException;
+
+public final class ColumnBinaryTestCase
+{
+    private ColumnBinaryTestCase() {}
+
+    public static String[] stringClassNames() throws IOException
+    {
+        return new String[]{
+            "jp.co.yahoo.yosegi.binary.maker.DumpBytesColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizeDumpStringColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizeIndexDumpStringColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeDumpStringColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeStringColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.RleStringColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.DictionaryRleStringColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayStringColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayDumpStringColumnBinaryMaker"};
+    }
+
+    public static String[] numberClassNames() throws IOException
+    {
+        return new String[]{
+            "jp.co.yahoo.yosegi.binary.maker.OptimizeDumpLongColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizeLongColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeDumpLongColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeLongColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.RleLongColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayLongColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayDumpLongColumnBinaryMaker"};
+    }
+
+    public static String[] floatClassNames() throws IOException
+    {
+        return new String[]{
+            "jp.co.yahoo.yosegi.binary.maker.DumpFloatColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizeFloatColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.RangeDumpFloatColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeFloatColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeRangeDumpFloatColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayFloatColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayDumpFloatColumnBinaryMaker"};
+    }
+
+    public static String[] doubleClassNames() throws IOException
+    {
+        return new String[]{
+            "jp.co.yahoo.yosegi.binary.maker.DumpDoubleColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizeDoubleColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.RangeDumpDoubleColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeOptimizeDoubleColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.UnsafeRangeDumpDoubleColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayDoubleColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayDumpDoubleColumnBinaryMaker"};
+    }
+
+    public static String[] booleanClassNames() throws IOException
+    {
+        return new String[]{
+            "jp.co.yahoo.yosegi.binary.maker.DumpBooleanColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.OptimizedNullArrayDumpBooleanColumnBinaryMaker",
+            "jp.co.yahoo.yosegi.binary.maker.FlagIndexedOptimizedNullArrayDumpBooleanColumnBinaryMaker"};
+    }
+
+    public static ColumnBinary createColumnBinary(String targetClassName, IColumn column) throws IOException
+    {
+        IColumnBinaryMaker maker = FindColumnBinaryMaker.get(targetClassName);
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        ColumnBinaryMakerCustomConfigNode configNode = new ColumnBinaryMakerCustomConfigNode("root", defaultConfig);
+        return maker.toBinary(defaultConfig, null, new CompressResultNode(), column);
+    }
+
+    public static ColumnBinary createStringColumnBinaryFromString(String[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createStringColumnBinaryFromString(defaultConfig.getColumnMaker(ColumnType.STRING).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createStringColumnBinaryFromString(String targetClassName, String[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.STRING, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.STRING, new StringObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createStringColumnBinaryFromBytes(byte[][] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createStringColumnBinaryFromBytes(defaultConfig.getColumnMaker(ColumnType.STRING).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createStringColumnBinaryFromBytes(String targetClassName, byte[][] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.STRING, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.STRING, new BytesObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createBooleanColumnBinaryFromBoolean(boolean[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createBooleanColumnBinaryFromBoolean(defaultConfig.getColumnMaker(ColumnType.BOOLEAN).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createBooleanColumnBinaryFromBoolean(String targetClassName, boolean[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.BOOLEAN, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.BOOLEAN, new BooleanObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createByteColumnBinaryFromByte(byte[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createByteColumnBinaryFromByte(defaultConfig.getColumnMaker(ColumnType.BYTE).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createByteColumnBinaryFromByte(String targetClassName, byte[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.BYTE, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.BYTE, new ByteObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createShortColumnBinaryFromShort(short[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createShortColumnBinaryFromShort(defaultConfig.getColumnMaker(ColumnType.SHORT).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createShortColumnBinaryFromShort(String targetClassName, short[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.SHORT, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.SHORT, new ShortObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createIntegerColumnBinaryFromInteger(int[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createIntegerColumnBinaryFromInteger(defaultConfig.getColumnMaker(ColumnType.INTEGER).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createIntegerColumnBinaryFromInteger(String targetClassName, int[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.INTEGER, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.INTEGER, new IntegerObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createLongColumnBinaryFromLong(long[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createLongColumnBinaryFromLong(defaultConfig.getColumnMaker(ColumnType.LONG).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createLongColumnBinaryFromLong(String targetClassName, long[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.LONG, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.LONG, new LongObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createFloatColumnBinaryFromFloat(float[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createFloatColumnBinaryFromFloat(defaultConfig.getColumnMaker(ColumnType.FLOAT).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createFloatColumnBinaryFromFloat(String targetClassName, float[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.FLOAT, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.FLOAT, new FloatObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static ColumnBinary createDoubleColumnBinaryFromDouble(double[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        ColumnBinaryMakerConfig defaultConfig = new ColumnBinaryMakerConfig();
+        return createDoubleColumnBinaryFromDouble(defaultConfig.getColumnMaker(ColumnType.DOUBLE).getClass().getName(), data, isNullArray, columnName);
+    }
+
+    public static ColumnBinary createDoubleColumnBinaryFromDouble(String targetClassName, double[] data, boolean[] isNullArray, String columnName) throws IOException
+    {
+        IColumn column = new PrimitiveColumn(ColumnType.DOUBLE, columnName);
+        for (int i = 0; i < data.length; i++) {
+            if (!isNullArray[i]) {
+                column.add(ColumnType.DOUBLE, new DoubleObj(data[i]), i);
+            }
+        }
+        return createColumnBinary(targetClassName, column);
+    }
+
+    public static IColumn toColumn(final ColumnBinary columnBinary) throws IOException {
+        return toColumn(columnBinary, columnBinary.rowCount);
+    }
+
+    public static IColumn toColumn(final ColumnBinary columnBinary, Integer loadCount) throws IOException {
+        if (loadCount == null) {
+            loadCount = (columnBinary.isSetLoadSize) ? columnBinary.loadSize : loadCount;
+        }
+        return new YosegiLoaderFactory().create(columnBinary, loadCount);
+    }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/YosegiFileTestCase.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/YosegiFileTestCase.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox;
+
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.io.DummyJobReporter;
+import jp.co.yahoo.yosegi.hive.io.HiveReaderSetting;
+import jp.co.yahoo.yosegi.hive.io.SpreadCounter;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.spread.expression.IExpressionNode;
+import jp.co.yahoo.yosegi.writer.YosegiWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public final class YosegiFileTestCase {
+
+  public static byte[] createYosegiFileBinary(
+      final List<List<ColumnBinary>> columnBinaryLists ,
+      final List<Integer> spreadSizeList ) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Configuration config = new Configuration();
+    YosegiWriter writer = new YosegiWriter( out , config );
+    for ( int i = 0 ; i < columnBinaryLists.size() ; i++ ) {
+      writer.appendRow( columnBinaryLists.get(i) , spreadSizeList.get(i) );
+    }
+    writer.close();
+    return out.toByteArray();
+  }
+
+  public static YosegiHiveLineReader createYosegiHiveLineReader(
+      final byte[] yosegiFile ,
+      final Configuration config ,
+      final IExpressionNode node ) throws IOException {
+    HiveReaderSetting readerSetting = new HiveReaderSetting(
+        config , node , false , false , false );
+    return new YosegiHiveLineReader(
+        new ByteArrayInputStream( yosegiFile ) ,
+        yosegiFile.length ,
+        0 ,
+        yosegiFile.length ,
+        readerSetting , 
+        new DummyJobReporter() ,
+        new SpreadCounter() );
+  }
+
+  public static YosegiHiveLineReader createYosegiFileBinaryAndCreateLineReader(
+      final List<List<ColumnBinary>> columnBinaryLists ,
+      final List<Integer> spreadSizeList ,
+      final Configuration config ,
+      final IExpressionNode node ) throws IOException {
+    return createYosegiHiveLineReader(
+        createYosegiFileBinary( columnBinaryLists , spreadSizeList ) ,
+        config ,
+        null );
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestBoolean.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestBoolean.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestBoolean {
+
+  public static void createTestCase(List<Arguments> args, boolean[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.booleanClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new boolean[]{true, true, false, false, true, true, false, false, true, true}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new boolean[]{false, true, false, false, false, true, false, false, false, true}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new boolean[]{false, false, false, false, false, true, false, false, true, true}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new boolean[]{true, true, false, false, true, false, false, false, false, false}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new boolean[]{true, false, false, false, false, false, false, false, false, false}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new boolean[]{true, true, true, true, true, true, true, true, true, true}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new boolean[]{false, true, false, true, false, true, false, true, false, true}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new boolean[]{false, false, false, false, false, true, true, true, true, true}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new boolean[]{true, true, true, true, true, false, false, false, false, false}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new boolean[]{true, false, false, false, false, false, false, false, false, true}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new boolean[]{false, false, false, false, false, false, false, false, false, true}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new boolean[]{true, false, false, false, false, false, false, false, false, false}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.booleanTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , boolean[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createBooleanColumnBinaryFromBoolean(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof BooleanWritable );
+        assertEquals( data[i] , ( (BooleanWritable) f ).get() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestByte.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestByte.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestByte {
+
+  public static void createTestCase(List<Arguments> args, byte[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+        createTestCase(args, new byte[]{(byte) 10, (byte) 20, (byte) 30, (byte) 40, (byte) 50, (byte) 10, (byte) 10, (byte) 20, (byte) 20, (byte) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+        createTestCase(args, new byte[]{(byte) 0, (byte) 20, (byte) 0, (byte) 40, (byte) 0, (byte) 10, (byte) 0, (byte) 20, (byte) 0, (byte) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+        createTestCase(args, new byte[]{(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, (byte) 10, (byte) 20, (byte) 20, (byte) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+        createTestCase(args, new byte[]{(byte) 10, (byte) 10, (byte) 20, (byte) 20, (byte) 30, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+        createTestCase(args, new byte[]{(byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+        createTestCase(args, new byte[]{(byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+        createTestCase(args, new byte[]{(byte) 0, (byte) 10, (byte) 0, (byte) 10, (byte) 0, (byte) 10, (byte) 0, (byte) 10, (byte) 0, (byte) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+        createTestCase(args, new byte[]{(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+        createTestCase(args, new byte[]{(byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+        createTestCase(args, new byte[]{(byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+        createTestCase(args, new byte[]{(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+        createTestCase(args, new byte[]{(byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.byteTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , byte[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createByteColumnBinaryFromByte(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof ByteWritable );
+        assertEquals( data[i] , ( (ByteWritable) f ).get() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestDouble.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestDouble.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestDouble {
+
+  public static void createTestCase(List<Arguments> args, double[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.doubleClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new double[]{(double) 10, (double) 20, (double) 30, (double) 40, (double) 50, (double) 10, (double) 10, (double) 20, (double) 20, (double) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 0, (double) 20, (double) 0, (double) 40, (double) 0, (double) 10, (double) 0, (double) 20, (double) 0, (double) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new double[]{(double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10, (double) 10, (double) 20, (double) 20, (double) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 10, (double) 10, (double) 20, (double) 20, (double) 30, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new double[]{(double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new double[]{(double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 0, (double) 10, (double) 0, (double) 10, (double) 0, (double) 10, (double) 0, (double) 10, (double) 0, (double) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new double[]{(double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new double[]{(double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new double[]{(double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new double[]{(double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.doubleTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , double[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createDoubleColumnBinaryFromDouble(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof DoubleWritable );
+        assertEquals( data[i] , ( (DoubleWritable) f ).get() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestFloat.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestFloat.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestFloat {
+
+  public static void createTestCase(List<Arguments> args, float[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.floatClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new float[]{(float) 10, (float) 20, (float) 30, (float) 40, (float) 50, (float) 10, (float) 10, (float) 20, (float) 20, (float) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 0, (float) 20, (float) 0, (float) 40, (float) 0, (float) 10, (float) 0, (float) 20, (float) 0, (float) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new float[]{(float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10, (float) 10, (float) 20, (float) 20, (float) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 10, (float) 10, (float) 20, (float) 20, (float) 30, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new float[]{(float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new float[]{(float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 0, (float) 10, (float) 0, (float) 10, (float) 0, (float) 10, (float) 0, (float) 10, (float) 0, (float) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new float[]{(float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new float[]{(float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new float[]{(float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new float[]{(float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.floatTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , float[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createFloatColumnBinaryFromFloat(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof FloatWritable );
+        assertEquals( data[i] , ( (FloatWritable) f ).get() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestInteger.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestInteger.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestInteger {
+
+  public static void createTestCase(List<Arguments> args, int[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new int[]{(int) 10, (int) 20, (int) 30, (int) 40, (int) 50, (int) 10, (int) 10, (int) 20, (int) 20, (int) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 0, (int) 20, (int) 0, (int) 40, (int) 0, (int) 10, (int) 0, (int) 20, (int) 0, (int) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new int[]{(int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10, (int) 10, (int) 20, (int) 20, (int) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 10, (int) 10, (int) 20, (int) 20, (int) 30, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new int[]{(int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new int[]{(int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 0, (int) 10, (int) 0, (int) 10, (int) 0, (int) 10, (int) 0, (int) 10, (int) 0, (int) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new int[]{(int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new int[]{(int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new int[]{(int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new int[]{(int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.intTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , int[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createIntegerColumnBinaryFromInteger(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof IntWritable );
+        assertEquals( data[i] , ( (IntWritable) f ).get() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestLong.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestLong.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestLong {
+
+  public static void createTestCase(List<Arguments> args, long[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new long[]{(long) 10, (long) 20, (long) 30, (long) 40, (long) 50, (long) 10, (long) 10, (long) 20, (long) 20, (long) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 0, (long) 20, (long) 0, (long) 40, (long) 0, (long) 10, (long) 0, (long) 20, (long) 0, (long) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new long[]{(long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10, (long) 10, (long) 20, (long) 20, (long) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 10, (long) 10, (long) 20, (long) 20, (long) 30, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new long[]{(long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new long[]{(long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 0, (long) 10, (long) 0, (long) 10, (long) 0, (long) 10, (long) 0, (long) 10, (long) 0, (long) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new long[]{(long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new long[]{(long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new long[]{(long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new long[]{(long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.longTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , long[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createLongColumnBinaryFromLong(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof LongWritable );
+        assertEquals( data[i] , ( (LongWritable) f ).get() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestShort.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestShort.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestShort {
+
+  public static void createTestCase(List<Arguments> args, short[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new short[]{(short) 10, (short) 20, (short) 30, (short) 40, (short) 50, (short) 10, (short) 10, (short) 20, (short) 20, (short) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 0, (short) 20, (short) 0, (short) 40, (short) 0, (short) 10, (short) 0, (short) 20, (short) 0, (short) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new short[]{(short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10, (short) 10, (short) 20, (short) 20, (short) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 10, (short) 10, (short) 20, (short) 20, (short) 30, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new short[]{(short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new short[]{(short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 0, (short) 10, (short) 0, (short) 10, (short) 0, (short) 10, (short) 0, (short) 10, (short) 0, (short) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new short[]{(short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new short[]{(short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new short[]{(short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new short[]{(short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.shortTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , short[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createShortColumnBinaryFromShort(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof ShortWritable );
+        assertEquals( data[i] , ( (ShortWritable) f ).get() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestString.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/line/TestString.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.NullWritable;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestString {
+
+  public static void createTestCase(List<Arguments> args, String[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.stringClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new String[]{"a", "ab", "abc", "abcd", "bc", "bc", "bc", "bc", "ab", ""}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new String[]{null, "ab", null, "abcd", null, "bc", null, "bc", null, ""}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new String[]{null, null, null, null, null, "b", "bc", "bc", "bcd", "bcd"}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new String[]{"b", "bc", "bc", "bcd", "bcd", null, null, null, null, null}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new String[]{"ab", null, null, null, null, null, null, null, null, "bc"}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new String[]{"ab", "ab", "ab", "ab", "ab", "ab", "ab", "ab", "ab", "ab"}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new String[]{null, "ab", null, "ab", null, "ab", null, "ab", null, "ab"}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new String[]{null, null, null, null, null, "ab", "ab", "ab", "ab", "ab"}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new String[]{"ab", "ab", "ab", "ab", "ab", null, null, null, null, null}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new String[]{"ab", null, null, null, null, null, null, null, null, "ab"}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new String[]{null, null, null, null, null, null, null, null, null, "ab"}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new String[]{"ab", null, null, null, null, null, null, null, null, null}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  public YosegiHiveLineReader createReader( final ColumnBinary columnBinary , final int spreadSize ) throws IOException {
+    return YosegiFileTestCase.createYosegiFileBinaryAndCreateLineReader(
+        Arrays.asList( Arrays.asList( columnBinary ) ) ,
+        Arrays.asList( spreadSize ) ,
+        new Configuration() ,
+        null );
+  }
+
+  public StructObjectInspector createObjectInspector(){
+    StructTypeInfo info = new StructTypeInfo();
+    ArrayList<String> nameList = new ArrayList<String>();
+    nameList.add( "col" ); 
+
+    ArrayList<TypeInfo> typeInfoList = new ArrayList<TypeInfo>( Arrays.asList( TypeInfoFactory.stringTypeInfo ) );
+
+    info.setAllStructFieldNames( nameList );
+    info.setAllStructFieldTypeInfos( typeInfoList );
+    return (StructObjectInspector)( YosegiObjectInspectorFactory.craeteObjectInspectorFromTypeInfo( info ) );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , String[] data , boolean[] isNullArray , int spreadSize ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createStringColumnBinaryFromString(targetClassName, data, isNullArray, "col");
+    YosegiHiveLineReader reader = createReader( columnBinary , spreadSize );
+    StructObjectInspector ins = createObjectInspector();
+    NullWritable key = reader.createKey();
+    ColumnAndIndex value = reader.createValue();
+    int i = 0;
+    while ( reader.next( key , value ) ) {
+      Object f = ins.getStructFieldData( value , ins.getStructFieldRef( "col" ) );
+      if ( isNullArray[i] ) {
+        assertNull( f );
+      } else {
+        assertTrue( f instanceof Text );
+        assertEquals( data[i] , ( (Text) f ).toString() );
+      }
+      i++;
+    }
+    reader.close();
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestByteVector.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestByteVector.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.io.NullWritable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.hive.io.vector.LongColumnVectorAssignor;
+import jp.co.yahoo.yosegi.hive.io.vector.LongPrimitiveSetter;
+import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestByteVector {
+
+  public static void createTestCase(List<Arguments> args, byte[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new byte[]{(byte) 10, (byte) 20, (byte) 30, (byte) 40, (byte) 50, (byte) 10, (byte) 10, (byte) 20, (byte) 20, (byte) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new byte[]{(byte) 0, (byte) 20, (byte) 0, (byte) 40, (byte) 0, (byte) 10, (byte) 0, (byte) 20, (byte) 0, (byte) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new byte[]{(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, (byte) 10, (byte) 20, (byte) 20, (byte) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new byte[]{(byte) 10, (byte) 10, (byte) 20, (byte) 20, (byte) 30, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new byte[]{(byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new byte[]{(byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new byte[]{(byte) 0, (byte) 10, (byte) 0, (byte) 10, (byte) 0, (byte) 10, (byte) 0, (byte) 10, (byte) 0, (byte) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new byte[]{(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new byte[]{(byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new byte[]{(byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new byte[]{(byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new byte[]{(byte) 10, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , byte[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createByteColumnBinaryFromByte(targetClassName, data, isNullArray, "col");
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (byte)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ){
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (byte)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndex( String targetClassName , byte[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createByteColumnBinaryFromByte(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 10);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ){
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (byte)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (byte)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndex( String targetClassName , byte[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createByteColumnBinaryFromByte(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ){
+      if( ! vector.isNull[i] ) {
+        assertEquals( (byte)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (byte)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLoadIndexIsTail5( String targetClassName , byte[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createByteColumnBinaryFromByte(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{0, 0, 0, 0, 0, 1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (byte)(vector.vector[i]) , data[i + 5] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (byte)(vector.vector[i]) , data[i + offset + 5] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndexAndExpand( String targetClassName , byte[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createByteColumnBinaryFromByte(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+    columnBinary.setRepetitions(loadIndex, 15);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 15 );
+    LongColumnVector vector = new LongColumnVector( 15 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 15 , column );
+    assignor.setColumnVector( vector , 0 , 15 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if (isNullArray[i]) {
+          assertTrue( vector.isNull[index] );
+        } else {
+          assertFalse( vector.isNull[index] );
+          assertEquals( data[i] , (byte)(vector.vector[n]) );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndexAndExpand( String targetClassName , byte[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createByteColumnBinaryFromByte(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+    columnBinary.setRepetitions(loadIndex, 20);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 20 );
+    LongColumnVector vector = new LongColumnVector( 20 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 20 , column );
+    assignor.setColumnVector( vector , 0 , 20 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if ( i < isNullArray.length ) {
+          if (isNullArray[i]) {
+            assertTrue( vector.isNull[index] );
+          } else {
+            assertFalse( vector.isNull[index] );
+            assertEquals( data[i] , (byte)(vector.vector[n]) );
+          }
+        } else {
+          assertTrue( vector.isNull[index] );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestDoubleVector.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestDoubleVector.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.io.NullWritable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.hive.io.vector.DoubleColumnVectorAssignor;
+import jp.co.yahoo.yosegi.hive.io.vector.DoublePrimitiveSetter;
+import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestDoubleVector {
+
+  public static void createTestCase(List<Arguments> args, double[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.doubleClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new double[]{(double) 10, (double) 20, (double) 30, (double) 40, (double) 50, (double) 10, (double) 10, (double) 20, (double) 20, (double) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 0, (double) 20, (double) 0, (double) 40, (double) 0, (double) 10, (double) 0, (double) 20, (double) 0, (double) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new double[]{(double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10, (double) 10, (double) 20, (double) 20, (double) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 10, (double) 10, (double) 20, (double) 20, (double) 30, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new double[]{(double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new double[]{(double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 0, (double) 10, (double) 0, (double) 10, (double) 0, (double) 10, (double) 0, (double) 10, (double) 0, (double) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new double[]{(double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10, (double) 10, (double) 10, (double) 10, (double) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new double[]{(double) 10, (double) 10, (double) 10, (double) 10, (double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new double[]{(double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new double[]{(double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new double[]{(double) 10, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0, (double) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , double[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createDoubleColumnBinaryFromDouble(targetClassName, data, isNullArray, "col");
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    DoubleColumnVector vector = new DoubleColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( DoublePrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (double)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ){
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (double)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndex( String targetClassName , double[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createDoubleColumnBinaryFromDouble(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 10);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    DoubleColumnVector vector = new DoubleColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( DoublePrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ){
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (double)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (double)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndex( String targetClassName , double[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createDoubleColumnBinaryFromDouble(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    DoubleColumnVector vector = new DoubleColumnVector( 5 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( DoublePrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ){
+      if( ! vector.isNull[i] ) {
+        assertEquals( (double)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (double)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLoadIndexIsTail5( String targetClassName , double[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createDoubleColumnBinaryFromDouble(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{0, 0, 0, 0, 0, 1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    DoubleColumnVector vector = new DoubleColumnVector( 5 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( DoublePrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (double)(vector.vector[i]) , data[i + 5] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (double)(vector.vector[i]) , data[i + offset + 5] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndexAndExpand( String targetClassName , double[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createDoubleColumnBinaryFromDouble(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+    columnBinary.setRepetitions(loadIndex, 15);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 15 );
+    DoubleColumnVector vector = new DoubleColumnVector( 15 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( DoublePrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 15 , column );
+    assignor.setColumnVector( vector , 0 , 15 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if (isNullArray[i]) {
+          assertTrue( vector.isNull[index] );
+        } else {
+          assertFalse( vector.isNull[index] );
+          assertEquals( data[i] , (double)(vector.vector[n]) );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndexAndExpand( String targetClassName , double[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createDoubleColumnBinaryFromDouble(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+    columnBinary.setRepetitions(loadIndex, 20);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 20 );
+    DoubleColumnVector vector = new DoubleColumnVector( 20 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( DoublePrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 20 , column );
+    assignor.setColumnVector( vector , 0 , 20 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if ( i < isNullArray.length ) {
+          if (isNullArray[i]) {
+            assertTrue( vector.isNull[index] );
+          } else {
+            assertFalse( vector.isNull[index] );
+            assertEquals( data[i] , (double)(vector.vector[n]) );
+          }
+        } else {
+          assertTrue( vector.isNull[index] );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestFloatVector.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestFloatVector.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.io.NullWritable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.hive.io.vector.DoubleColumnVectorAssignor;
+import jp.co.yahoo.yosegi.hive.io.vector.FloatPrimitiveSetter;
+import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestFloatVector {
+
+  public static void createTestCase(List<Arguments> args, float[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.floatClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new float[]{(float) 10, (float) 20, (float) 30, (float) 40, (float) 50, (float) 10, (float) 10, (float) 20, (float) 20, (float) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 0, (float) 20, (float) 0, (float) 40, (float) 0, (float) 10, (float) 0, (float) 20, (float) 0, (float) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new float[]{(float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10, (float) 10, (float) 20, (float) 20, (float) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 10, (float) 10, (float) 20, (float) 20, (float) 30, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new float[]{(float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new float[]{(float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 0, (float) 10, (float) 0, (float) 10, (float) 0, (float) 10, (float) 0, (float) 10, (float) 0, (float) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new float[]{(float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10, (float) 10, (float) 10, (float) 10, (float) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new float[]{(float) 10, (float) 10, (float) 10, (float) 10, (float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new float[]{(float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new float[]{(float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new float[]{(float) 10, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0, (float) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , float[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createFloatColumnBinaryFromFloat(targetClassName, data, isNullArray, "col");
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    DoubleColumnVector vector = new DoubleColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( FloatPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (float)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ){
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (float)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndex( String targetClassName , float[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createFloatColumnBinaryFromFloat(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 10);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    DoubleColumnVector vector = new DoubleColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( FloatPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ){
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (float)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (float)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndex( String targetClassName , float[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createFloatColumnBinaryFromFloat(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    DoubleColumnVector vector = new DoubleColumnVector( 5 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( FloatPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ){
+      if( ! vector.isNull[i] ) {
+        assertEquals( (float)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (float)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLoadIndexIsTail5( String targetClassName , float[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createFloatColumnBinaryFromFloat(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{0, 0, 0, 0, 0, 1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    DoubleColumnVector vector = new DoubleColumnVector( 5 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( FloatPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (float)(vector.vector[i]) , data[i + 5] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (float)(vector.vector[i]) , data[i + offset + 5] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndexAndExpand( String targetClassName , float[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createFloatColumnBinaryFromFloat(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+    columnBinary.setRepetitions(loadIndex, 15);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 15 );
+    DoubleColumnVector vector = new DoubleColumnVector( 15 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( FloatPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 15 , column );
+    assignor.setColumnVector( vector , 0 , 15 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if (isNullArray[i]) {
+          assertTrue( vector.isNull[index] );
+        } else {
+          assertFalse( vector.isNull[index] );
+          assertEquals( data[i] , (float)(vector.vector[n]) );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndexAndExpand( String targetClassName , float[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createFloatColumnBinaryFromFloat(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+    columnBinary.setRepetitions(loadIndex, 20);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 20 );
+    DoubleColumnVector vector = new DoubleColumnVector( 20 );
+    IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( FloatPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 20 , column );
+    assignor.setColumnVector( vector , 0 , 20 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if ( i < isNullArray.length ) {
+          if (isNullArray[i]) {
+            assertTrue( vector.isNull[index] );
+          } else {
+            assertFalse( vector.isNull[index] );
+            assertEquals( data[i] , (float)(vector.vector[n]) );
+          }
+        } else {
+          assertTrue( vector.isNull[index] );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestIntegerVector.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestIntegerVector.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.io.NullWritable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.hive.io.vector.LongColumnVectorAssignor;
+import jp.co.yahoo.yosegi.hive.io.vector.LongPrimitiveSetter;
+import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestIntegerVector {
+
+  public static void createTestCase(List<Arguments> args, int[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new int[]{(int) 10, (int) 20, (int) 30, (int) 40, (int) 50, (int) 10, (int) 10, (int) 20, (int) 20, (int) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 0, (int) 20, (int) 0, (int) 40, (int) 0, (int) 10, (int) 0, (int) 20, (int) 0, (int) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new int[]{(int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10, (int) 10, (int) 20, (int) 20, (int) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 10, (int) 10, (int) 20, (int) 20, (int) 30, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new int[]{(int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new int[]{(int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 0, (int) 10, (int) 0, (int) 10, (int) 0, (int) 10, (int) 0, (int) 10, (int) 0, (int) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new int[]{(int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10, (int) 10, (int) 10, (int) 10, (int) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new int[]{(int) 10, (int) 10, (int) 10, (int) 10, (int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new int[]{(int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new int[]{(int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new int[]{(int) 10, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0, (int) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , int[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createIntegerColumnBinaryFromInteger(targetClassName, data, isNullArray, "col");
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (int)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ){
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (int)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndex( String targetClassName , int[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createIntegerColumnBinaryFromInteger(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 10);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ){
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (int)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (int)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndex( String targetClassName , int[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createIntegerColumnBinaryFromInteger(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ){
+      if( ! vector.isNull[i] ) {
+        assertEquals( (int)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (int)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLoadIndexIsTail5( String targetClassName , int[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createIntegerColumnBinaryFromInteger(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{0, 0, 0, 0, 0, 1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (int)(vector.vector[i]) , data[i + 5] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (int)(vector.vector[i]) , data[i + offset + 5] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndexAndExpand( String targetClassName , int[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createIntegerColumnBinaryFromInteger(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+    columnBinary.setRepetitions(loadIndex, 15);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 15 );
+    LongColumnVector vector = new LongColumnVector( 15 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 15 , column );
+    assignor.setColumnVector( vector , 0 , 15 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if (isNullArray[i]) {
+          assertTrue( vector.isNull[index] );
+        } else {
+          assertFalse( vector.isNull[index] );
+          assertEquals( data[i] , (int)(vector.vector[n]) );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndexAndExpand( String targetClassName , int[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createIntegerColumnBinaryFromInteger(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+    columnBinary.setRepetitions(loadIndex, 20);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 20 );
+    LongColumnVector vector = new LongColumnVector( 20 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 20 , column );
+    assignor.setColumnVector( vector , 0 , 20 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if ( i < isNullArray.length ) {
+          if (isNullArray[i]) {
+            assertTrue( vector.isNull[index] );
+          } else {
+            assertFalse( vector.isNull[index] );
+            assertEquals( data[i] , (int)(vector.vector[n]) );
+          }
+        } else {
+          assertTrue( vector.isNull[index] );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestLongVector.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestLongVector.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.io.NullWritable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.hive.io.vector.LongColumnVectorAssignor;
+import jp.co.yahoo.yosegi.hive.io.vector.LongPrimitiveSetter;
+import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestLongVector {
+
+  public static void createTestCase(List<Arguments> args, long[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new long[]{(long) 10, (long) 20, (long) 30, (long) 40, (long) 50, (long) 10, (long) 10, (long) 20, (long) 20, (long) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 0, (long) 20, (long) 0, (long) 40, (long) 0, (long) 10, (long) 0, (long) 20, (long) 0, (long) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new long[]{(long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10, (long) 10, (long) 20, (long) 20, (long) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 10, (long) 10, (long) 20, (long) 20, (long) 30, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new long[]{(long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new long[]{(long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 0, (long) 10, (long) 0, (long) 10, (long) 0, (long) 10, (long) 0, (long) 10, (long) 0, (long) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new long[]{(long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10, (long) 10, (long) 10, (long) 10, (long) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new long[]{(long) 10, (long) 10, (long) 10, (long) 10, (long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new long[]{(long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new long[]{(long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new long[]{(long) 10, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0, (long) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , long[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createLongColumnBinaryFromLong(targetClassName, data, isNullArray, "col");
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (long)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ){
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (long)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndex( String targetClassName , long[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createLongColumnBinaryFromLong(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 10);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ){
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (long)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (long)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndex( String targetClassName , long[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createLongColumnBinaryFromLong(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ){
+      if( ! vector.isNull[i] ) {
+        assertEquals( (long)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (long)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLoadIndexIsTail5( String targetClassName , long[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createLongColumnBinaryFromLong(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{0, 0, 0, 0, 0, 1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (long)(vector.vector[i]) , data[i + 5] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (long)(vector.vector[i]) , data[i + offset + 5] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndexAndExpand( String targetClassName , long[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createLongColumnBinaryFromLong(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+    columnBinary.setRepetitions(loadIndex, 15);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 15 );
+    LongColumnVector vector = new LongColumnVector( 15 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 15 , column );
+    assignor.setColumnVector( vector , 0 , 15 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if (isNullArray[i]) {
+          assertTrue( vector.isNull[index] );
+        } else {
+          assertFalse( vector.isNull[index] );
+          assertEquals( data[i] , (long)(vector.vector[n]) );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndexAndExpand( String targetClassName , long[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createLongColumnBinaryFromLong(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+    columnBinary.setRepetitions(loadIndex, 20);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 20 );
+    LongColumnVector vector = new LongColumnVector( 20 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 20 , column );
+    assignor.setColumnVector( vector , 0 , 20 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if ( i < isNullArray.length ) {
+          if (isNullArray[i]) {
+            assertTrue( vector.isNull[index] );
+          } else {
+            assertFalse( vector.isNull[index] );
+            assertEquals( data[i] , (long)(vector.vector[n]) );
+          }
+        } else {
+          assertTrue( vector.isNull[index] );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestShortVector.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestShortVector.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.io.NullWritable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.hive.io.vector.LongColumnVectorAssignor;
+import jp.co.yahoo.yosegi.hive.io.vector.LongPrimitiveSetter;
+import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestShortVector {
+
+  public static void createTestCase(List<Arguments> args, short[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.numberClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new short[]{(short) 10, (short) 20, (short) 30, (short) 40, (short) 50, (short) 10, (short) 10, (short) 20, (short) 20, (short) 30}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 0, (short) 20, (short) 0, (short) 40, (short) 0, (short) 10, (short) 0, (short) 20, (short) 0, (short) 30}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new short[]{(short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10, (short) 10, (short) 20, (short) 20, (short) 30}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 10, (short) 10, (short) 20, (short) 20, (short) 30, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new short[]{(short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new short[]{(short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 0, (short) 10, (short) 0, (short) 10, (short) 0, (short) 10, (short) 0, (short) 10, (short) 0, (short) 10}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new short[]{(short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10, (short) 10, (short) 10, (short) 10, (short) 10}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new short[]{(short) 10, (short) 10, (short) 10, (short) 10, (short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new short[]{(short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new short[]{(short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 10}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new short[]{(short) 10, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0, (short) 0}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , short[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createShortColumnBinaryFromShort(targetClassName, data, isNullArray, "col");
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (short)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ){
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (short)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndex( String targetClassName , short[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createShortColumnBinaryFromShort(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 10);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    LongColumnVector vector = new LongColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ){
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( (short)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( (short)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndex( String targetClassName , short[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createShortColumnBinaryFromShort(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ){
+      if( ! vector.isNull[i] ) {
+        assertEquals( (short)(vector.vector[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (short)(vector.vector[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLoadIndexIsTail5( String targetClassName , short[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createShortColumnBinaryFromShort(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{0, 0, 0, 0, 0, 1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    LongColumnVector vector = new LongColumnVector( 5 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (short)(vector.vector[i]) , data[i + 5] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( (short)(vector.vector[i]) , data[i + offset + 5] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndexAndExpand( String targetClassName , short[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createShortColumnBinaryFromShort(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+    columnBinary.setRepetitions(loadIndex, 15);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 15 );
+    LongColumnVector vector = new LongColumnVector( 15 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 15 , column );
+    assignor.setColumnVector( vector , 0 , 15 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if (isNullArray[i]) {
+          assertTrue( vector.isNull[index] );
+        } else {
+          assertFalse( vector.isNull[index] );
+          assertEquals( data[i] , (short)(vector.vector[n]) );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndexAndExpand( String targetClassName , short[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createShortColumnBinaryFromShort(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+    columnBinary.setRepetitions(loadIndex, 20);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 20 );
+    LongColumnVector vector = new LongColumnVector( 20 );
+    IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
+
+    assignor.setColumn( 20 , column );
+    assignor.setColumnVector( vector , 0 , 20 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if ( i < isNullArray.length ) {
+          if (isNullArray[i]) {
+            assertTrue( vector.isNull[index] );
+          } else {
+            assertFalse( vector.isNull[index] );
+            assertEquals( data[i] , (short)(vector.vector[n]) );
+          }
+        } else {
+          assertTrue( vector.isNull[index] );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestStringVector.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/blackbox/vector/TestStringVector.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.yosegi.hive.blackbox.line;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.io.NullWritable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import jp.co.yahoo.yosegi.binary.ColumnBinary;
+import jp.co.yahoo.yosegi.config.Configuration;
+import jp.co.yahoo.yosegi.spread.column.IColumn;
+import jp.co.yahoo.yosegi.hive.blackbox.ColumnBinaryTestCase;
+import jp.co.yahoo.yosegi.hive.blackbox.YosegiFileTestCase;
+import jp.co.yahoo.yosegi.hive.YosegiObjectInspectorFactory;
+import jp.co.yahoo.yosegi.hive.io.ColumnAndIndex;
+import jp.co.yahoo.yosegi.hive.io.YosegiHiveLineReader;
+import jp.co.yahoo.yosegi.hive.io.vector.BytesColumnVectorAssignor;
+import jp.co.yahoo.yosegi.hive.io.vector.IColumnVectorAssignor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public final class TestStringVector {
+
+  public static void createTestCase(List<Arguments> args, String[] data, boolean[] isNullArray) throws IOException {
+    String[] testClassArray = ColumnBinaryTestCase.stringClassNames();
+    for (int i = 0; i < testClassArray.length; i++) {
+      args.add(arguments(testClassArray[i], data, isNullArray, isNullArray.length));
+    }
+  }
+
+  public static Stream<Arguments> data() throws IOException {
+    // 通常のデータ
+    List<Arguments> args = new ArrayList<Arguments>();
+    createTestCase(args, new String[]{"a", "ab", "abc", "abcd", "bc", "bc", "bc", "bc", "ab", ""}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new String[]{null, "ab", null, "abcd", null, "bc", null, "bc", null, ""}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new String[]{null, null, null, null, null, "b", "bc", "bc", "bcd", "bcd"}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new String[]{"b", "bc", "bc", "bcd", "bcd", null, null, null, null, null}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new String[]{"ab", null, null, null, null, null, null, null, null, "bc"}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+
+    // 固定の値のデータ
+    createTestCase(args, new String[]{"ab", "ab", "ab", "ab", "ab", "ab", "ab", "ab", "ab", "ab"}, new boolean[]{false, false, false, false, false, false, false, false, false, false});
+    createTestCase(args, new String[]{null, "ab", null, "ab", null, "ab", null, "ab", null, "ab"}, new boolean[]{true, false, true, false, true, false, true, false, true, false});
+    createTestCase(args, new String[]{null, null, null, null, null, "ab", "ab", "ab", "ab", "ab"}, new boolean[]{true, true, true, true, true, false, false, false, false, false});
+    createTestCase(args, new String[]{"ab", "ab", "ab", "ab", "ab", null, null, null, null, null}, new boolean[]{false, false, false, false, false, true, true, true, true, true});
+    createTestCase(args, new String[]{"ab", null, null, null, null, null, null, null, null, "ab"}, new boolean[]{false, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new String[]{null, null, null, null, null, null, null, null, null, "ab"}, new boolean[]{true, true, true, true, true, true, true, true, true, false});
+    createTestCase(args, new String[]{"ab", null, null, null, null, null, null, null, null, null}, new boolean[]{false, true, true, true, true, true, true, true, true, true});
+    return args.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue( String targetClassName , String[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createStringColumnBinaryFromString(targetClassName, data, isNullArray, "col");
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    BytesColumnVector vector = new BytesColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ){
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndex( String targetClassName , String[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createStringColumnBinaryFromString(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 10);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 10 );
+    BytesColumnVector vector = new BytesColumnVector( column.size() );
+    IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
+
+    assignor.setColumn( column.size() , column );
+    int offset = column.size() / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( vector.isNull[i] ){
+        assertTrue(isNullArray[i]);
+      } else {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (column.size() - offset) );
+    for( int i = 0 ; i < column.size() - offset ; i++ ) {
+      if( vector.isNull[i] ) {
+        assertTrue(isNullArray[i + offset]);
+      } else {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndex( String targetClassName , String[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createStringColumnBinaryFromString(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    BytesColumnVector vector = new BytesColumnVector( 5 );
+    IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ){
+      if( ! vector.isNull[i] ) {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i + offset] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLoadIndexIsTail5( String targetClassName , String[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createStringColumnBinaryFromString(targetClassName, data, isNullArray, "col");
+    columnBinary.setRepetitions(new int[]{0, 0, 0, 0, 0, 1, 1, 1, 1, 1}, 5);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 5 );
+    BytesColumnVector vector = new BytesColumnVector( 5 );
+    IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
+
+    assignor.setColumn( 5 , column );
+    int offset = 5 / 2;
+    assignor.setColumnVector( vector , 0 , offset );
+    for( int i = 0 ; i < offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i + 5] );
+      }
+    }
+    vector.reset();
+    assignor.setColumnVector( vector , offset , (5 - offset) );
+    for( int i = 0 ; i < 5 - offset ; i++ ) {
+      if( ! vector.isNull[i] ) {
+        assertEquals( new String(vector.vector[i],vector.start[i],vector.length[i]) , data[i + offset + 5] );
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withAllValueIndexAndExpand( String targetClassName , String[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createStringColumnBinaryFromString(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+    columnBinary.setRepetitions(loadIndex, 15);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 15 );
+    BytesColumnVector vector = new BytesColumnVector( 15 );
+    IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
+
+    assignor.setColumn( 15 , column );
+    assignor.setColumnVector( vector , 0 , 15 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if (isNullArray[i]) {
+          assertTrue( vector.isNull[index] );
+        } else {
+          assertFalse( vector.isNull[index] );
+          assertEquals( data[i] , new String(vector.vector[n],vector.start[n],vector.length[n]) );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void T_load_equalsSetValue_withLargeLoadIndexAndExpand( String targetClassName , String[] data , boolean[] isNullArray ) throws IOException {
+    ColumnBinary columnBinary = ColumnBinaryTestCase.createStringColumnBinaryFromString(targetClassName, data, isNullArray, "col");
+    int[] loadIndex = new int[]{2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+    columnBinary.setRepetitions(loadIndex, 20);
+    IColumn column = ColumnBinaryTestCase.toColumn( columnBinary , 20 );
+    BytesColumnVector vector = new BytesColumnVector( 20 );
+    IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
+
+    assignor.setColumn( 20 , column );
+    assignor.setColumnVector( vector , 0 , 20 );
+    int index = 0;
+    for ( int i = 0 ; i < loadIndex.length ; i++ ) {
+      for ( int n = index ; n < index + loadIndex[i] ; n++ ) {
+        if ( i < isNullArray.length ) {
+          if (isNullArray[i]) {
+            assertTrue( vector.isNull[index] );
+          } else {
+            assertFalse( vector.isNull[index] );
+            assertEquals( data[i] , new String(vector.vector[n],vector.start[n],vector.length[n]) );
+          }
+        } else {
+          assertTrue( vector.isNull[index] );
+        }
+      }
+      index += loadIndex[i];
+    }
+  }
+}

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/TestYosegiHiveRecordWriter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/TestYosegiHiveRecordWriter.java
@@ -32,13 +32,12 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.reader.YosegiReader;
 import jp.co.yahoo.yosegi.spread.Spread;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import jp.co.yahoo.yosegi.config.Configuration;
 import jp.co.yahoo.yosegi.message.parser.*;
 import jp.co.yahoo.yosegi.message.parser.json.*;
 import jp.co.yahoo.yosegi.message.objects.*;
+import jp.co.yahoo.yosegi.hive.io.vector.ColumnUtil;
 
 import jp.co.yahoo.yosegi.*;
 
@@ -69,16 +68,14 @@ public class TestYosegiHiveRecordWriter{
     while( reader.hasNext() ){
       Spread spread = reader.next();
       IColumn key1Column = spread.getColumn( "key1" );
-      IExpressionIndex indexList = new AllExpressionIndex( spread.size() );
-      PrimitiveObject[] primitiveArray = key1Column.getPrimitiveObjectArray( indexList , 0 , spread.size() );
-      assertEquals( 7 , primitiveArray.length );
-      assertEquals( "a" , primitiveArray[0].getString() );
-      assertEquals( "b" , primitiveArray[1].getString() );
-      assertEquals( "a" , primitiveArray[2].getString() );
-      assertEquals( "b" , primitiveArray[3].getString() );
-      assertEquals( "a" , primitiveArray[4].getString() );
-      assertEquals( "b" , primitiveArray[5].getString() );
-      assertEquals( "a" , primitiveArray[6].getString() );
+      assertEquals( 7 , key1Column.size() );
+      assertEquals( "a" , ColumnUtil.getPrimitiveObject( key1Column , 0 ).getString() );
+      assertEquals( "b" , ColumnUtil.getPrimitiveObject( key1Column , 1 ).getString() );
+      assertEquals( "a" , ColumnUtil.getPrimitiveObject( key1Column , 2 ).getString() );
+      assertEquals( "b" , ColumnUtil.getPrimitiveObject( key1Column , 3 ).getString() );
+      assertEquals( "a" , ColumnUtil.getPrimitiveObject( key1Column , 4 ).getString() );
+      assertEquals( "b" , ColumnUtil.getPrimitiveObject( key1Column , 5 ).getString() );
+      assertEquals( "a" , ColumnUtil.getPrimitiveObject( key1Column , 6 ).getString() );
     }
   }
 

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestBytePrimitiveSetter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestBytePrimitiveSetter.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,15 +47,14 @@ public class TestBytePrimitiveSetter{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.BYTE , new ByteObj( (byte)( i % 128 ) ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     INumberPrimitiveSetter setter = BytePrimitiveSetter.getInstance();
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      PrimitiveObject[] pArray = column.getPrimitiveObjectArray( index , start , 1024 );
       LongColumnVector vector = new LongColumnVector( 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
-        setter.set( pArray , vector , n );
+        PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , start + n );
+        setter.set( primitiveObject , vector , n );
       } 
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestBytesColumnVectorAssignor.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestBytesColumnVectorAssignor.java
@@ -34,8 +34,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -51,7 +49,6 @@ public class TestBytesColumnVectorAssignor{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.BYTES , new BytesObj( Integer.toString( i ).getBytes() ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     BytesColumnVector vector = new BytesColumnVector( 1024 );
     IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
@@ -59,7 +56,7 @@ public class TestBytesColumnVectorAssignor{
 
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      assignor.setColumnVector( vector , index , start , 1024 );
+      assignor.setColumnVector( vector , start , 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){
           assertTrue( Arrays.equals( vector.vector[n] , Integer.toString( n + start ).getBytes() ) );
@@ -78,7 +75,6 @@ public class TestBytesColumnVectorAssignor{
       byte[] a = Integer.toString( i ).getBytes();
       column.add( ColumnType.BYTES , new Utf8BytesLinkObj( a , 0 , a.length ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     BytesColumnVector vector = new BytesColumnVector( 1024 );
     IColumnVectorAssignor assignor = new BytesColumnVectorAssignor();
@@ -86,7 +82,7 @@ public class TestBytesColumnVectorAssignor{
 
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      assignor.setColumnVector( vector , index , start , 1024 );
+      assignor.setColumnVector( vector , start , 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){
           assertTrue( Arrays.equals( vector.vector[n] , Integer.toString( n + start ).getBytes() ) );

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestDoubleColumnVectorAssignor.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestDoubleColumnVectorAssignor.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,7 +47,6 @@ public class TestDoubleColumnVectorAssignor{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.DOUBLE , new DoubleObj( (double)i / (double)1000 ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     DoubleColumnVector vector = new DoubleColumnVector( 1024 );
     IColumnVectorAssignor assignor = new DoubleColumnVectorAssignor( DoublePrimitiveSetter.getInstance() );
@@ -57,7 +54,7 @@ public class TestDoubleColumnVectorAssignor{
 
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      assignor.setColumnVector( vector , index , start , 1024 );
+      assignor.setColumnVector( vector , start , 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){
           assertEquals( vector.vector[n] , (double)( n + start ) / (double)1000 );

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestDoublePrimitiveSetter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestDoublePrimitiveSetter.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,15 +47,14 @@ public class TestDoublePrimitiveSetter{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.DOUBLE , new DoubleObj( (double)i/(double)1000 ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     IDecimalPrimitiveSetter setter = DoublePrimitiveSetter.getInstance();
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      PrimitiveObject[] pArray = column.getPrimitiveObjectArray( index , start , 1024 );
       DoubleColumnVector vector = new DoubleColumnVector( 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
-        setter.set( pArray , vector , n );
+        PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , start + n );
+        setter.set( primitiveObject , vector , n );
       } 
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestFloatPrimitiveSetter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestFloatPrimitiveSetter.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,15 +47,14 @@ public class TestFloatPrimitiveSetter{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.FLOAT , new FloatObj( (float)i/(float)1000 ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     IDecimalPrimitiveSetter setter = FloatPrimitiveSetter.getInstance();
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      PrimitiveObject[] pArray = column.getPrimitiveObjectArray( index , start , 1024 );
       DoubleColumnVector vector = new DoubleColumnVector( 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
-        setter.set( pArray , vector , n );
+        PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , start + n );
+        setter.set( primitiveObject , vector , n );
       } 
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestIntegerPrimitiveSetter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestIntegerPrimitiveSetter.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,15 +47,14 @@ public class TestIntegerPrimitiveSetter{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.INTEGER , new IntegerObj( i % 128 ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     INumberPrimitiveSetter setter = IntegerPrimitiveSetter.getInstance();
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      PrimitiveObject[] pArray = column.getPrimitiveObjectArray( index , start , 1024 );
       LongColumnVector vector = new LongColumnVector( 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
-        setter.set( pArray , vector , n );
+        PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , start + n );
+        setter.set( primitiveObject , vector , n );
       } 
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestLongColumnVectorAssignor.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestLongColumnVectorAssignor.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,7 +47,6 @@ public class TestLongColumnVectorAssignor{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.LONG , new LongObj( i ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     LongColumnVector vector = new LongColumnVector( 1024 );
     IColumnVectorAssignor assignor = new LongColumnVectorAssignor( LongPrimitiveSetter.getInstance() );
@@ -57,7 +54,7 @@ public class TestLongColumnVectorAssignor{
 
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      assignor.setColumnVector( vector , index , start , 1024 );
+      assignor.setColumnVector( vector , start , 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){
           assertEquals( vector.vector[n] , ( n + start ) );

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestLongPrimitiveSetter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestLongPrimitiveSetter.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,15 +47,14 @@ public class TestLongPrimitiveSetter{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.LONG , new LongObj( i % 128 ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     INumberPrimitiveSetter setter = LongPrimitiveSetter.getInstance();
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      PrimitiveObject[] pArray = column.getPrimitiveObjectArray( index , start , 1024 );
       LongColumnVector vector = new LongColumnVector( 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
-        setter.set( pArray , vector , n );
+        PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , start + n );
+        setter.set( primitiveObject , vector , n );
       } 
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestShortPrimitiveSetter.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/vector/TestShortPrimitiveSetter.java
@@ -32,8 +32,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import jp.co.yahoo.yosegi.spread.column.ColumnType;
 import jp.co.yahoo.yosegi.spread.column.IColumn;
 import jp.co.yahoo.yosegi.spread.column.PrimitiveColumn;
-import jp.co.yahoo.yosegi.spread.expression.AllExpressionIndex;
-import jp.co.yahoo.yosegi.spread.expression.IExpressionIndex;
 
 import org.apache.hadoop.hive.ql.exec.vector.*;
 
@@ -49,15 +47,14 @@ public class TestShortPrimitiveSetter{
     for( int i = 0 ; i < 2000 ; i++ ){
       column.add( ColumnType.SHORT , new ShortObj( (short)( i % 128 ) ) , i );
     }
-    IExpressionIndex index = new AllExpressionIndex( column.size() );
 
     INumberPrimitiveSetter setter = ShortPrimitiveSetter.getInstance();
     for( int i = 0 ; i < 3 ; i++ ){
       int start = i * 1024;
-      PrimitiveObject[] pArray = column.getPrimitiveObjectArray( index , start , 1024 );
       LongColumnVector vector = new LongColumnVector( 1024 );
       for( int n = 0 ; n < 1024 ; n++ ){
-        setter.set( pArray , vector , n );
+        PrimitiveObject primitiveObject = ColumnUtil.getPrimitiveObject( column , start + n );
+        setter.set( primitiveObject , vector , n );
       } 
       for( int n = 0 ; n < 1024 ; n++ ){
         if( ( n + start ) < 2000 ){


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Fixed the handling of getPrimitiveObject, which was deprecated in 2.0.0.

### How did you do the test? (Not required for updating documents)
Rewrote the unit test.