### PR TITLE
An exception handling has been added in case the target column can't be obtaned when perfoming pushdown.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/hive/YosegiListObjectInspector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/YosegiListObjectInspector.java
@@ -128,7 +128,11 @@ public class YosegiListObjectInspector implements SettableListObjectInspector {
         return null;
       }
     } else {
-      return ( (List)object ).get( index );
+      if ( index < getListLength( object ) ) {
+        return ( (List)object ).get( index );
+      } else {
+        return null;
+      }
     }
   }
 

--- a/src/main/java/jp/co/yahoo/yosegi/hive/YosegiMapObjectInspector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/YosegiMapObjectInspector.java
@@ -131,6 +131,9 @@ public class YosegiMapObjectInspector implements SettableMapObjectInspector {
       return getField.get( childColumn , columnAndIndex.index , columnAndIndex.columnIndex );
     } else {
       Map map = (Map)object;
+      if ( map == null ) {
+        return null;
+      }
       return map.get( key.toString() );
     }
   }
@@ -154,6 +157,9 @@ public class YosegiMapObjectInspector implements SettableMapObjectInspector {
 
   @Override
   public int getMapSize( final Object object ) {
+    if ( object == null ) {
+      return 0;
+    }
     return ((Map)object).size();
   }
 

--- a/src/main/java/jp/co/yahoo/yosegi/hive/pushdown/CreateExtractNodeUtil.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/pushdown/CreateExtractNodeUtil.java
@@ -109,6 +109,9 @@ public final class CreateExtractNodeUtil {
         .getWritableConstantValue().toString() );
 
     IExtractNode parentExtraNode = getExtractNode( columnDesc );
+    if ( parentExtraNode == null ) {
+      return null;
+    }
 
     parentExtraNode.pushChild( childExtraNode );
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

1. An exception handling has been added in case the target column can't be obtaned when perfoming pushdown.
2. Added exception handling when the target object is NULL.

### How did you do the test? (Not required for updating documents)

Improved NullPointerException in Hive.