### PR TITLE
[1.2.1]Fixed a bug where Pushdown settings were not enabled.

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/HiveReaderSetting.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/HiveReaderSetting.java
@@ -81,6 +81,8 @@ public class HiveReaderSetting implements IReaderSetting {
     if ( filterExprSerialized != null ) {
       filterExprs.add( Utilities.deserializeExpression(filterExprSerialized) );
     }
+    config.set( "spread.reader.read.column.names" , createReadColumnNames(
+        job.get( ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR , null ) ) );
 
     MapWork mapWork;
     try {
@@ -126,9 +128,6 @@ public class HiveReaderSetting implements IReaderSetting {
     }
 
     node = createExpressionNode( filterExprs );
-
-    config.set( "spread.reader.read.column.names" , createReadColumnNames(
-        job.get( ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR , null ) ) );
 
     // Next Hive vesion;
     // Utilities.getUseVectorizedInputFileFormat(job)


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

Fixed a bug where projection pushdown was not enabled when loading a Hive table from Spark.

### How did you do the test? (Not required for updating documents)
