### PR TITLE
Fixed to return empty array instead of null

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/hive/YosegiListObjectInspector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/YosegiListObjectInspector.java
@@ -176,7 +176,7 @@ public class YosegiListObjectInspector implements SettableListObjectInspector {
         }
         return result;
       }
-      return null;
+      return new ArrayList<>();
     } else {
       return (List)object;
     }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Since YosegiListObjectInspector's create method creates an empty array, getList method must similarly return an empty array, not null.

### How did you do the test? (Not required for updating documents)
