### PR TITLE
[hive-1.2.1000.2.6.5.0-292]Set empty yosegi config if read column is not present.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,11 @@ custom_filters:
   merge_only: &merge_only
     filters:
       branches:
-        only: hive-1.2.1000.2.6.4.0-91
+        only: hive-1.2.1000.2.6.5.0-292
   merge_ignore: &merge_ignore
     filters:
       branches:
-        ignore: hive-1.2.1000.2.6.4.0-91
+        ignore: hive-1.2.1000.2.6.5.0-292
 
 workflows:
   build-and-test:

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi-hive</artifactId>
-  <version>2.0.7_hive-1.2.1000.2.6.4.0-91-SNAPSHOT</version>
+  <version>2.0.7_hive-1.2.1000.2.6.5.0-292-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Yosegi Hive</name>
   <description>Yosegi Hive library.</description>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <version>1.2.1000.2.6.4.0-91</version>
+      <version>1.2.1000.2.6.5.0-292</version>
       <optional>true</optional>
       <exclusions>
         <exclusion>
@@ -253,8 +253,8 @@
         <version>2.5.3</version>
         <configuration>
           <releaseProfiles>gpg-sign</releaseProfiles>
-          <releaseVersion>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}_hive-1.2.1000.2.6.4.0-91</releaseVersion>
-          <developmentVersion>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.nextIncrementalVersion}_hive-1.2.1000.2.6.4.0-91-SNAPSHOT</developmentVersion>
+          <releaseVersion>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}_hive-1.2.1000.2.6.5.0-292</releaseVersion>
+          <developmentVersion>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.nextIncrementalVersion}_hive-1.2.1000.2.6.5.0-292-SNAPSHOT</developmentVersion>
         </configuration>
       </plugin>
       <plugin>
@@ -298,14 +298,14 @@
   </build>
 
   <repositories>
-    <repository>
+    <!--repository>
       <id>hdp</id>
-      <url> http://repo.hortonworks.com/content/repositories/releases</url>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
       <name>HDP</name>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-    </repository>
+    </repository-->
     <repository>
       <id>pentaho</id>
       <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/HiveReaderSetting.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/HiveReaderSetting.java
@@ -149,7 +149,7 @@ public class HiveReaderSetting implements IReaderSetting {
    * Create the setting of the column to be read by Yosegi.
    */
   public String createReadColumnNames( final String readColumnNames ) {
-    if ( readColumnNames == null || readColumnNames.isEmpty() ) {
+    if ( readColumnNames == null ) {
       return null;
     }
     StringBuilder jsonStringBuilder = new StringBuilder();

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/TestHiveReaderSetting.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/TestHiveReaderSetting.java
@@ -67,7 +67,7 @@ public class TestHiveReaderSetting{
   public void T_createReadColumnNames_2(){
     HiveReaderSetting setting = new HiveReaderSetting( null , null , false , false , false );
     String readColumnJson = setting.createReadColumnNames( "" );
-    assertEquals( readColumnJson , null );
+    assertEquals( readColumnJson , "[]" );
   }
 
   @Test


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

For operations such as counting the entire table, there is no need to read any columns.
With the current settings, if there are no columns to read, all columns will be read.
With this fix, yosegi will be configured not to read columns if there are no columns to read.

### How did you do the test? (Not required for updating documents)
