### PR TITLE
[hive-2.3.9]Set empty yosegi config if read column is not present.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,14 +300,6 @@
 
   <repositories>
     <repository>
-      <id>hdp</id>
-      <url> http://repo.hortonworks.com/content/repositories/releases</url>
-      <name>HDP</name>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <id>pentaho</id>
       <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
       <name>PENTAHO</name>

--- a/src/main/java/jp/co/yahoo/yosegi/hive/io/HiveReaderSetting.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/io/HiveReaderSetting.java
@@ -141,7 +141,7 @@ public class HiveReaderSetting implements IReaderSetting {
    * Create the setting of the column to be read by Yosegi.
    */
   public String createReadColumnNames( final String readColumnNames ) {
-    if ( readColumnNames == null || readColumnNames.isEmpty() ) {
+    if ( readColumnNames == null ) {
       return null;
     }
     StringBuilder jsonStringBuilder = new StringBuilder();

--- a/src/test/java/jp/co/yahoo/yosegi/hive/io/TestHiveReaderSetting.java
+++ b/src/test/java/jp/co/yahoo/yosegi/hive/io/TestHiveReaderSetting.java
@@ -67,7 +67,7 @@ public class TestHiveReaderSetting{
   public void T_createReadColumnNames_2(){
     HiveReaderSetting setting = new HiveReaderSetting( null , null , false , false , false );
     String readColumnJson = setting.createReadColumnNames( "" );
-    assertEquals( readColumnJson , null );
+    assertEquals( readColumnJson , "[]" );
   }
 
   @Test


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

For operations such as counting the entire table, there is no need to read any columns.
With the current settings, if there are no columns to read, all columns will be read.
With this fix, yosegi will be configured not to read columns if there are no columns to read.

### How did you do the test? (Not required for updating documents)
