### PR TITLE
[hive-1.2.1000.2.6.4.0-91]Fixed a bug that caused invalid values ​​when Map children were nested types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>jp.co.yahoo.yosegi</groupId>
       <artifactId>yosegi</artifactId>
-      <version>2.0.2</version>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>jp.co.yahoo.yosegi</groupId>

--- a/src/main/java/jp/co/yahoo/yosegi/hive/YosegiMapObjectInspector.java
+++ b/src/main/java/jp/co/yahoo/yosegi/hive/YosegiMapObjectInspector.java
@@ -134,7 +134,10 @@ public class YosegiMapObjectInspector implements SettableMapObjectInspector {
             new ColumnAndIndex(targetColumn, columnAndIndex.index, columnAndIndex.columnIndex);
       }
       IColumn childColumn = columnAndIndex.column.getColumn( key.toString() );
-      return getField.get( childColumn , columnAndIndex.index , columnAndIndex.columnIndex );
+      return getField.get(
+          childColumn ,
+          columnAndIndex.index ,
+          columnAndIndex.column.getChildColumnIndex( childColumn.getColumnName() ) );
     } else {
       Map map = (Map)object;
       if ( map == null ) {
@@ -158,7 +161,7 @@ public class YosegiMapObjectInspector implements SettableMapObjectInspector {
       for ( int i = 0 ; i < childColumnSize ; i++ ) {
         IColumn childColumn = columnAndIndex.column.getColumn(i);
         Object value =
-            getField.get( childColumn , columnAndIndex.index , columnAndIndex.columnIndex );
+            getField.get( childColumn , columnAndIndex.index , i );
         result.put(childColumn.getColumnName(), value);
       }
       return result;


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

When the child type of a Map is a nested type, the referenced column will be in the same position.
An element with a different key may be read as the value.

### How did you do the test? (Not required for updating documents)
